### PR TITLE
Directory for every file extension  (Better organization)

### DIFF
--- a/Src/HitmanExtractor/Program.cs
+++ b/Src/HitmanExtractor/Program.cs
@@ -9,6 +9,8 @@ namespace HitmanExtractor
 {
     public static class Program
     {
+        private static readonly List<string> FoundFileType = new List<string>();
+        
         class HitmanException : Exception
         {
             public HitmanException(string message)
@@ -159,6 +161,9 @@ namespace HitmanExtractor
 
                 var fileEntry = fileEntries[i];
                 fileEntry.FileType = fileType;
+                
+                if (!FoundFileType.Contains(fileType)) FoundFileType.Add(fileType);
+                
                 fileEntry.DecompressedFileSize = decompressedSize;
 
                 fileEntry.FileTable2EntryOffset = (ulong) fileTableOffset;
@@ -190,7 +195,7 @@ namespace HitmanExtractor
 
         private static void ExtractFileEntryList(BinaryReader binaryReader, List<FileEntry> fileEntryList, string outputDirectory, List<string> filters)
         {
-            Directory.CreateDirectory(outputDirectory);
+            foreach (var extension in FoundFileType) Directory.CreateDirectory($"{outputDirectory}/{new string(extension.ToCharArray().Reverse().ToArray())}");
 
             foreach (var fileEntry in fileEntryList)
             {
@@ -226,7 +231,7 @@ namespace HitmanExtractor
 
                 var fileExtension = new string(fileEntry.FileType.ToCharArray().Reverse().ToArray());
 
-                File.WriteAllBytes(Path.Combine(outputDirectory, $"{fileEntry.Hash:X16}.{fileExtension.ToLower()}"), bytes);
+                File.WriteAllBytes(Path.Combine($"{outputDirectory}/{fileExtension}", $"{fileEntry.Hash:X16}.{fileExtension.ToLower()}"), bytes);
 
                 Console.WriteLine($"EXTRACTED: {fileEntry.FileType} => {fileEntry.Hash} @ {fileEntry.FileOffset} ({fileEntry.ActualFileSize} / {fileEntry.DecompressedFileSize})");
             }


### PR DESCRIPTION
This will prevent users to fetch everything at once in a single directory.

There is a list that keeps track of all existing file types. After building an entry list, it will create separate directories with extension names.